### PR TITLE
Include example application properties

### DIFF
--- a/electionreminders/.gitignore
+++ b/electionreminders/.gitignore
@@ -1,1 +1,4 @@
 /target
+/src/main/resources/application-secrets.properties
+/src/main/resources/keystore.jks
+/src/main/resources/keystore.p12

--- a/electionreminders/README.md
+++ b/electionreminders/README.md
@@ -1,16 +1,20 @@
 # ElectionRemindersBackend
 # ElectionReminders
 
-Goal: 
+# Goal: 
 To create a mobile app which offers the user the ability to set up reminders for important elections (local and national). In this repo, we have the backend logic for this app (written with Java and Spring Boot)
 
-Technology: 
+# Technology: 
 Java 21, Maven 3.8.5, Spring Boot, SQL 
 
-How to get started: 
+# How to get started: 
 Firstly build the project. You can do this with the VSCODE IDE when you simply press shift,ctrl, p and select the "Java: Rebuild Projects" command.
 Then simply start the application in "Application.java". Right now - this will turn on a few test endpoints 
 which will run on localhost:8443. The app is running on ssh to allow for testing purposes. To run the app, you also need a application.properties file and associated .jks (Java keystore)files and .p12 (PKCS) files. Front end components can call these endpoints and receive dummy data.  The startpoint for the app is "Application.java". 
 
-Database logic. 
+# Database logic. 
 The programme uses a sql database to return elections. Please start a sql database (I use pgadmin) beforehand. 
+
+# application.properties and settings.
+This app has multiple settings. You can view what settings are needed in application.properties. You can add the necessary
+passwords and sensitive data in a application-secrets.properties file. 

--- a/electionreminders/src/main/resources/application.properties
+++ b/electionreminders/src/main/resources/application.properties
@@ -1,0 +1,16 @@
+spring.config.import=application-secrets.properties
+
+server.ssl.key-store=xxx
+server.ssl.key-store-password=xxx
+server.ssl.key-alias=xxx
+server.port=8443
+
+spring.datasource.url=xxx
+spring.datasource.username=xxx
+spring.datasource.password=xxx
+spring.datasource.driver-class-name=xxx
+
+# JPA Properties
+spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true


### PR DESCRIPTION
The backend app has multiple settings required for the app to run correctly. This PR adds a example application.properties file so other developers know what is required (without betraying sensitive data)